### PR TITLE
The whole path does not appear inside the app if you choose a subpath and not the root of a domain

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 Environment=PORT=__PORT__
-Environment=HOSTNAME=__DOMAIN__
+Environment=HOSTNAME=__PATH_URL__
 Environment=GIN_MODE=release
 Environment=FORWARD_IP_HEADER=X-Forwarded-For
 Environment="__YNH_GO_LOAD_PATH__"

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 Environment=PORT=__PORT__
-Environment=HOSTNAME=__PATH_URL__
+Environment=HOSTNAME=__DOMAIN__/__PATH_URL__
 Environment=GIN_MODE=release
 Environment=FORWARD_IP_HEADER=X-Forwarded-For
 Environment="__YNH_GO_LOAD_PATH__"

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 Environment=PORT=__PORT__
-Environment=HOSTNAME=__DOMAIN__/__PATH_URL__
+Environment=HOSTNAME=__DOMAIN____PATH_URL__
 Environment=GIN_MODE=release
 Environment=FORWARD_IP_HEADER=X-Forwarded-For
 Environment="__YNH_GO_LOAD_PATH__"


### PR DESCRIPTION
## Problem

- As of now, if you choose a subpath and not just the root of a domain, the whole path does not appear inside the app

## Solution

- Set the Hostname correctly to report the domain and the subpath

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
